### PR TITLE
Centralise logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 4. Create your own `final class Encryption.java` in `app/src/main/java/com.memory_athlete.memoryassistant/inAppBilling/`. Add `static` functions, `decrypt` and `addSomePepper` with return type `String`. You can return empty strings. 
 5. Remove apk signing by removing `keystoreProperties` and `signingConfigs{...}` from app level `build.gradle`. To use your own signature, refer to the [documentation](https://developer.android.com/studio/publish/app-signing).
 6. Add your own `google-services.json` to `app/src/`. Download it by linking your builds to Firebase. To run the app without it remove – all mentions to firebase from the app level `build.gradle`; `meta-data` tag from the `AndroidManifests.xml`. **Do NOT remove `firebase-jobdispatcher`** it is important for reminders.
-7. Add your own `fabric.properties` to `app/src/`. Download it after connecting your builds to [Crashlytics](https://console.firebase.google.com/project/_/crashlytics) through Fabric. To run the app without it remove – the crashlytics dependency and fabric repository and plugin from `build.gradle`; the `meta-data` tag from the `AndroidManifests.xml`; Crashlytics calls from all java files. 
+7. Add your own `fabric.properties` to `app/src/`. Download it after connecting your builds to [Crashlytics](https://console.firebase.google.com/project/_/crashlytics) through Fabric. To run the app without it, run in debug or remove the crashlytics dependency and fabric repository and plugin from `build.gradle`; the `meta-data` tag from the `AndroidManifests.xml`; Crashlytics calls from all java files. 
 8. Keep googling the errors that you face.
 
 * **Dependencies**

--- a/app/src/main/java/com/memory_athlete/memoryassistant/disciplines/DisciplineFragment.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/disciplines/DisciplineFragment.java
@@ -32,7 +32,6 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
-import com.crashlytics.android.Crashlytics;
 import com.memory_athlete.memoryassistant.Helper;
 import com.memory_athlete.memoryassistant.R;
 import com.memory_athlete.memoryassistant.main.RecallSelector;
@@ -529,8 +528,8 @@ public abstract class DisciplineFragment extends Fragment implements View.OnClic
         intent.putExtra("file exists", fileExists);
         intent.putExtra(getString(R.string.discipline), "" + activity.getTitle());
 
-        Crashlytics.log("DisciplineFragment/fileExists = " + fileExists);
-        Crashlytics.log("DisciplineFragment/discipline = " + activity.getTitle());
+        Timber.i("DisciplineFragment/fileExists = " + fileExists);
+        Timber.i("DisciplineFragment/discipline = " + activity.getTitle());
 
         // no need to send filename as the most recent file within the disciplint is selected
 

--- a/app/src/main/java/com/memory_athlete/memoryassistant/disciplines/Numbers.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/disciplines/Numbers.java
@@ -16,7 +16,6 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 
-import com.crashlytics.android.Crashlytics;
 import com.memory_athlete.memoryassistant.Helper;
 import com.memory_athlete.memoryassistant.R;
 import com.memory_athlete.memoryassistant.main.RecallSelector;
@@ -238,8 +237,8 @@ public class Numbers extends DisciplineFragment {
             intent.putExtra("file exists", fileExists);
             intent.putExtra("discipline", "Digits");
 
-            Crashlytics.log("Numbers/fileExists = " + fileExists);
-            Crashlytics.log("Numbers/discipline = Digits");
+            Timber.i("Numbers/fileExists = " + fileExists);
+            Timber.i("Numbers/discipline = Digits");
 
             Timber.v("recalling Digits");
             startActivity(intent);

--- a/app/src/main/java/com/memory_athlete/memoryassistant/lessons/LessonFragment.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/lessons/LessonFragment.java
@@ -22,7 +22,6 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
-import com.crashlytics.android.Crashlytics;
 import com.memory_athlete.memoryassistant.Helper;
 import com.memory_athlete.memoryassistant.R;
 
@@ -81,9 +80,9 @@ public class LessonFragment extends Fragment {
         } else {                                                                    // Asset
 
             if (bundle.getBoolean("list", false)) {                  // list
-                Crashlytics.log("activity = " + activity.getLocalClassName());
-                Crashlytics.log("bundle = " + bundle);
-                Crashlytics.log("title = " + activity.getTitle());
+                Timber.i("activity = " + activity.getLocalClassName());
+                Timber.i("bundle = " + bundle);
+                Timber.i("title = " + activity.getTitle());
 
                 ArrayList<Item> list = readAssetList(bundle);
 
@@ -171,11 +170,11 @@ public class LessonFragment extends Fragment {
             reader.close();
             return sb;
         } catch (IOException e) {
-            Crashlytics.logException(e);
+            Timber.e(e);
             try {
                 reader.close();
             } catch (Exception e1) {
-                Crashlytics.logException(e1);
+                Timber.e(e1);
             }
             Toast.makeText(activity, "Try again", Toast.LENGTH_SHORT).show();
             activity.finish();
@@ -243,7 +242,7 @@ public class LessonFragment extends Fragment {
             try {
                 if (reader != null) reader.close();
             } catch (IOException e1) {
-                Crashlytics.logException(e1);
+                Timber.e(e1);
             }
             activity.finish();
         } catch (Exception e) {

--- a/app/src/main/java/com/memory_athlete/memoryassistant/lessons/Lessons.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/lessons/Lessons.java
@@ -25,7 +25,6 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
 
-import com.crashlytics.android.Crashlytics;
 import com.memory_athlete.memoryassistant.Helper;
 import com.memory_athlete.memoryassistant.R;
 import com.memory_athlete.memoryassistant.mySpace.MySpace;
@@ -263,7 +262,7 @@ public class Lessons extends AppCompatActivity {
             try {
                 if (reader != null) reader.close();
             } catch (IOException e1) {
-                Crashlytics.logException(e1);
+                Timber.e(e1);
             }
             finish();
         }
@@ -327,7 +326,7 @@ public class Lessons extends AppCompatActivity {
                     listItemView = LayoutInflater.from(getContext()).inflate(
                             R.layout.item_lesson_list, null, true);
             } catch (Resources.NotFoundException e) {
-                // Crashlytics.logException(e);
+                // Timber.e(e);
                 Toast.makeText(getContext(), R.string.dl_from_play, Toast.LENGTH_LONG).show();
                 throw new RuntimeException("Not downloaded from the Play Store");
             }

--- a/app/src/main/java/com/memory_athlete/memoryassistant/main/CrashlyticsLogTree.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/main/CrashlyticsLogTree.java
@@ -1,0 +1,33 @@
+package com.memory_athlete.memoryassistant.main;
+
+import android.util.Log;
+
+import com.crashlytics.android.Crashlytics;
+
+import timber.log.Timber;
+
+public class CrashlyticsLogTree extends Timber.Tree {
+    private static final String CRASHLYTICS_KEY_PRIORITY = "priority";
+    private static final String CRASHLYTICS_KEY_TAG = "tag";
+    private static final String CRASHLYTICS_KEY_MESSAGE = "message";
+
+    @Override
+    protected void log(int priority, String tag, String message, Throwable throwable) {
+        if (priority == Log.VERBOSE || priority == Log.DEBUG) {
+            return;
+        } else if (priority == Log.INFO) {
+            Crashlytics.log(priority, tag, message);
+            return;
+        }
+
+        Crashlytics.setInt(CRASHLYTICS_KEY_PRIORITY, priority);
+        Crashlytics.setString(CRASHLYTICS_KEY_TAG, tag);
+        Crashlytics.setString(CRASHLYTICS_KEY_MESSAGE, message);
+
+        if (throwable != null) {
+            Crashlytics.logException(throwable);
+        } else {
+            Crashlytics.logException(new Exception(message));
+        }
+    }
+}

--- a/app/src/main/java/com/memory_athlete/memoryassistant/main/MainActivity.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/main/MainActivity.java
@@ -78,7 +78,12 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Fabric.with(this, new Crashlytics());
+        if (BuildConfig.DEBUG) {
+            Timber.plant(new Timber.DebugTree());
+        } else {
+            Fabric.with(this, new Crashlytics());
+            Timber.plant(new CrashlyticsLogTree());
+        }
         if (BuildConfig.DEBUG) Timber.plant(new Timber.DebugTree());
 
         Helper.theme(this, MainActivity.this);

--- a/app/src/main/java/com/memory_athlete/memoryassistant/main/RecallSelector.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/main/RecallSelector.java
@@ -21,7 +21,6 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.crashlytics.android.Crashlytics;
 import com.google.android.material.snackbar.Snackbar;
 import com.memory_athlete.memoryassistant.Helper;
 import com.memory_athlete.memoryassistant.R;
@@ -52,7 +51,7 @@ public class RecallSelector extends AppCompatActivity {
             Helper.theme(this, this);
             setContentView(R.layout.activity_my_space);
         } catch (Resources.NotFoundException e) {
-            // Crashlytics.logException(e);
+            // Timber.e(e);
             Toast.makeText(this, R.string.dl_from_play, Toast.LENGTH_LONG).show();
             finish();
             return;
@@ -195,9 +194,9 @@ public class RecallSelector extends AppCompatActivity {
             intent.putExtra("file", filePath);                                 // discipline
             intent.putExtra("discipline", mDiscipline);
 
-            Crashlytics.log("RecallSelector/name = " + item.mName);             // file's readable name (without extension)
-            Crashlytics.log("RecallSelector/file = " + filePath);               // filepath
-            Crashlytics.log("RecallSelector/discipline = " + mDiscipline);      // discipline
+            Timber.i("RecallSelector/name = " + item.mName);             // file's readable name (without extension)
+            Timber.i("RecallSelector/file = " + filePath);               // filepath
+            Timber.i("RecallSelector/discipline = " + mDiscipline);      // discipline
 
             File file = new File(filePath);
             boolean isDirectoryCreated = file.exists();

--- a/app/src/main/java/com/memory_athlete/memoryassistant/mySpace/MySpace.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/mySpace/MySpace.java
@@ -44,7 +44,7 @@ public class MySpace extends AppCompatActivity {
         try {
             setContentView(R.layout.activity_my_space);
         } catch (Resources.NotFoundException e) {
-            // Crashlytics.logException(e);
+            // Timber.e(e);
             Toast.makeText(this, R.string.dl_from_play, Toast.LENGTH_LONG).show();
             finish();
             return;

--- a/app/src/main/java/com/memory_athlete/memoryassistant/mySpace/MySpaceFragment.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/mySpace/MySpaceFragment.java
@@ -99,7 +99,7 @@ public class MySpaceFragment extends Fragment {
         try {
             rootView = inflater.inflate(R.layout.fragment_my_space, container, false);
         } catch (Resources.NotFoundException e) {
-            // Crashlytics.logException(e);
+            // Timber.e(e);
             Toast.makeText(getActivity(), R.string.dl_from_play, Toast.LENGTH_LONG).show();
             Objects.requireNonNull(getActivity()).finish();
             return rootView;

--- a/app/src/main/java/com/memory_athlete/memoryassistant/recall/RecallComplex.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/recall/RecallComplex.java
@@ -71,7 +71,7 @@ public class RecallComplex extends RecallSimple {
     @Override
     protected void getAnswers() throws FileNotFoundException {
         if (answers.size() > 0) {
-            Timber.i("getAnswers() is returning early because the answers have already been read");
+            Timber.v("getAnswers() is returning early because the answers have already been read");
             return;
         }
         Timber.v("getAnswersEntered");

--- a/app/src/main/java/com/memory_athlete/memoryassistant/recall/RecallSimple.java
+++ b/app/src/main/java/com/memory_athlete/memoryassistant/recall/RecallSimple.java
@@ -21,7 +21,6 @@ import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
 
-import com.crashlytics.android.Crashlytics;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.memory_athlete.memoryassistant.Helper;
 import com.memory_athlete.memoryassistant.R;
@@ -91,9 +90,9 @@ public class RecallSimple extends AppCompatActivity {
         mDiscipline = intent.getStringExtra(getString(R.string.discipline));
         mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
 
-        Crashlytics.log("file Path = " + mFilePath);
-        Crashlytics.log("discipline = " + mDiscipline);
-        Crashlytics.log("file exists = " + intent.getBooleanExtra("file exists", false));
+        Timber.i("file Path = " + mFilePath);
+        Timber.i("discipline = " + mDiscipline);
+        Timber.i("file exists = " + intent.getBooleanExtra("file exists", false));
 
         setTitle(mDiscipline);
 
@@ -620,7 +619,7 @@ public class RecallSimple extends AppCompatActivity {
                 else if (compareFormat == CompareFormat.WORD_COMPARE_FORMAT) compare(true);
                 return false;
             } catch (FileNotFoundException e) {
-                Crashlytics.logException(e);
+                Timber.e(e);
                 return true;
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath 'com.google.gms:google-services:4.3.2'
         classpath 'com.google.firebase:perf-plugin:1.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"       // at line 4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 31 10:28:58 IST 2019
+#Sat Oct 19 14:06:10 BST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
I've centralised the crashlytics calls using timber, so that app can run in debug without having to comment out all the exception logging etc. 

In order to make a standard log to Crashlytics use Timber.i, anything above info will log a crashlytics exception. Crashlytics will only be used when running in release.
